### PR TITLE
[Feature Fix] Add Extra to Rensen-Connect's Supported Difficulties

### DIFF
--- a/Server/dist/Game/index.js
+++ b/Server/dist/Game/index.js
@@ -6,4 +6,5 @@ var GameDifficulty;
     GameDifficulty["NORMAL"] = "normal";
     GameDifficulty["HARD"] = "hard";
     GameDifficulty["LUNATIC"] = "lunatic";
+    GameDifficulty["EXTRA"] = "extra";
 })(GameDifficulty = exports.GameDifficulty || (exports.GameDifficulty = {}));

--- a/Server/src/Game/index.ts
+++ b/Server/src/Game/index.ts
@@ -11,4 +11,5 @@ export enum GameDifficulty {
     NORMAL = "normal",
     HARD = "hard",
     LUNATIC = "lunatic",
+    EXTRA = "extra"
 }


### PR DESCRIPTION
Currently, Difficulty Extra is not defined in the enumerator GameDifficulty, Which is a valid game difficulty, According to fork by @rosenrose, this issue was identified.  

![image](https://user-images.githubusercontent.com/27724108/59972045-8fc8b400-95c2-11e9-82ce-ddd6c3bce3c9.png)
